### PR TITLE
[Silabs] Re-enables LCD support for 917 NCP/RCP combination

### DIFF
--- a/examples/platform/linux/BUILD.gn
+++ b/examples/platform/linux/BUILD.gn
@@ -108,7 +108,7 @@ source_set("app-main") {
     ":wifi-diagnostics-test-event-trigger",
     "${chip_root}/src/data-model-providers/codegen:instance-header",
     "${chip_root}/src/lib",
-    "${chip_root}/src/platform/logging:default",
+    "${chip_root}/src/platform/logging:stdio",
   ]
   deps = [
     ":ota-test-event-trigger",

--- a/scripts/build/clang_coverage_wrapper.py
+++ b/scripts/build/clang_coverage_wrapper.py
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import logging
+import os
+import sys
 
 import click
 import coloredlogs
@@ -80,9 +82,16 @@ def main(log_level, no_log_timestamps, output, raw_profile_filename):
         log_fmt = "%(levelname)-7s %(message)s"
     coloredlogs.install(level=__LOG_LEVELS__[log_level], fmt=log_fmt)
 
+    expected_output = jinja2.Template(_CPP_TEMPLATE).render(raw_profile_filename=raw_profile_filename)
+    if os.path.exists(output):
+        with open(output, 'rt') as f:
+            if f.read() == expected_output:
+                logging.info("File %s is already as expected. Will not re-write", output)
+                sys.exit(0)
+
     logging.info("Writing output to %s (profile name: %s)", output, raw_profile_filename)
     with open(output, "wt") as f:
-        f.write(jinja2.Template(_CPP_TEMPLATE).render(raw_profile_filename=raw_profile_filename))
+        f.write(expected_output)
 
     logging.debug("Writing completed")
 

--- a/src/app/AttributePathExpandIterator.h
+++ b/src/app/AttributePathExpandIterator.h
@@ -25,7 +25,6 @@
 #include <lib/core/DataModelTypes.h>
 #include <lib/support/LinkedList.h>
 #include <lib/support/Span.h>
-#include <messaging/ExchangeContext.h>
 
 #include <limits>
 

--- a/src/darwin/CHIPTool/CHIPTool/Framework Helpers/FabricKeys.m
+++ b/src/darwin/CHIPTool/CHIPTool/Framework Helpers/FabricKeys.m
@@ -227,7 +227,7 @@ static const NSString * MTRCAKeyChainLabel = @"matter-tool.nodeopcerts.CA:0";
         return nil;
     }
 
-    return (__bridge_transfer NSData *) outData;
+    return (__bridge_transfer NSData *) cfData;
 }
 
 - (void)dealloc

--- a/src/darwin/Framework/CHIP/MTRDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice.mm
@@ -133,6 +133,8 @@ MTR_DIRECT_MEMBERS
     // TODO: retain cycle and clean up https://github.com/project-chip/connectedhomeip/issues/34267
     MTR_LOG("MTRDevice dealloc: %p", self);
 
+    [_deviceController deviceDeallocated];
+
     // Locking because _cancelAllAttributeValueWaiters has os_unfair_lock_assert_owner(&_lock)
     std::lock_guard lock(_lock);
     [self _cancelAllAttributeValueWaiters];

--- a/src/darwin/Framework/CHIP/MTRDeviceController.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceController.h
@@ -22,6 +22,7 @@
 #import <Matter/MTROperationalCertificateIssuer.h>
 
 @class MTRBaseDevice;
+@class MTRDevice;
 @class MTRServerEndpoint; // Defined in MTRServerEndpoint.h, which imports MTRAccessGrant.h, which imports MTRBaseClusters.h, which imports this file, so we can't import it.
 
 @class MTRDeviceControllerAbstractParameters;
@@ -81,6 +82,12 @@ MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  */
 @property (readonly, nonatomic, nullable)
     NSNumber * controllerNodeID MTR_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4));
+
+/**
+ * Returns the list of MTRDevice instances that this controller has loaded
+ * into memory. Returns an empty array if no devices are in memory.
+ */
+@property (readonly, nonatomic) NSArray<MTRDevice *> * devices MTR_AVAILABLE(ios(18.4), macos(15.4), watchos(11.4), tvos(18.4));
 
 /**
  * Set up a commissioning session for a device, using the provided setup payload

--- a/src/darwin/Framework/CHIP/MTRDeviceController.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceController.h
@@ -321,7 +321,7 @@ MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  * information.  Returns empty list if the controller does not have any
  * information stored.
  */
-- (NSArray<NSNumber *> *)nodesWithStoredData MTR_AVAILABLE(ios(18.4), macos(15.4), watchos(11.4), tvos(18.4));
+@property (readonly, nonatomic) NSArray<NSNumber *> * nodesWithStoredData MTR_AVAILABLE(ios(18.4), macos(15.4), watchos(11.4), tvos(18.4));
 
 /**
  * Shut down the controller. Calls to shutdown after the first one are NO-OPs.

--- a/src/darwin/Framework/CHIP/MTRDeviceController.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController.mm
@@ -381,6 +381,11 @@ using namespace chip::Tracing::DarwinFramework;
     MTRDevice * deviceToReturn = [_nodeIDToDeviceMap objectForKey:nodeID];
     if (!deviceToReturn && createIfNeeded) {
         deviceToReturn = [self _setupDeviceForNodeID:nodeID prefetchedClusterData:nil];
+        [self _callDelegatesWithBlock:^(id<MTRDeviceControllerDelegate> delegate) {
+            if ([delegate respondsToSelector:@selector(devicesChangedForController:)]) {
+                [delegate devicesChangedForController:self];
+            }
+        } logString:__PRETTY_FUNCTION__];
     }
 
     return deviceToReturn;
@@ -414,6 +419,27 @@ using namespace chip::Tracing::DarwinFramework;
     } else {
         MTR_LOG_ERROR("%@ Error: Cannot remove device %p with nodeID %llu", self, device, nodeID.unsignedLongLongValue);
     }
+}
+
+- (NSArray<MTRDevice *> *)devices
+{
+    std::lock_guard lock(*self.deviceMapLock);
+    NSMutableArray * devicesToReturn = [NSMutableArray array];
+
+    for (MTRDevice * device in _nodeIDToDeviceMap.objectEnumerator) {
+        [devicesToReturn addObject:device];
+    }
+
+    return devicesToReturn;
+}
+
+- (void)deviceDeallocated
+{
+    [self _callDelegatesWithBlock:^(id<MTRDeviceControllerDelegate> delegate) {
+        if ([delegate respondsToSelector:@selector(devicesChangedForController:)]) {
+            [delegate devicesChangedForController:self];
+        }
+    } logString:__PRETTY_FUNCTION__];
 }
 
 - (BOOL)setOperationalCertificateIssuer:(nullable id<MTROperationalCertificateIssuer>)operationalCertificateIssuer

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerDataStore.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerDataStore.h
@@ -109,7 +109,7 @@ typedef void (^MTRDeviceControllerDataStoreClusterDataHandler)(NSDictionary<NSNu
  * Returns the list of node IDs for which this data store has stored data of
  * some sort.
  */
-- (NSArray<NSNumber *> *)nodesWithStoredData;
+@property (readonly, nonatomic) NSArray<NSNumber *> * nodesWithStoredData;
 
 @end
 

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerDelegate.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerDelegate.h
@@ -106,6 +106,12 @@ MTR_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4))
  */
 - (void)controller:(MTRDeviceController *)controller
     suspendedChangedTo:(BOOL)suspended MTR_AVAILABLE(ios(18.2), macos(15.2), watchos(11.2), tvos(18.2));
+
+/**
+ * Notify the delegate when the list of MTRDevice objects in memory has changed.
+ */
+- (void)devicesChangedForController:(MTRDeviceController *)controller MTR_AVAILABLE(ios(18.4), macos(15.4), watchos(11.4), tvos(18.4));
+
 @end
 
 typedef NS_ENUM(NSUInteger, MTRPairingStatus) {

--- a/src/darwin/Framework/CHIP/MTRDeviceController_Concrete.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_Concrete.mm
@@ -1760,7 +1760,7 @@ static inline void emitMetricForSetupPayload(MTRSetupPayload * payload)
         return @[];
     }
 
-    return [self.controllerDataStore nodesWithStoredData];
+    return self.controllerDataStore.nodesWithStoredData;
 }
 
 @end

--- a/src/darwin/Framework/CHIP/MTRDeviceController_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_Internal.h
@@ -116,6 +116,11 @@ NS_ASSUME_NONNULL_BEGIN
 - (MTRDevice *)_setupDeviceForNodeID:(NSNumber *)nodeID prefetchedClusterData:(nullable NSDictionary<MTRClusterPath *, MTRDeviceClusterData *> *)prefetchedClusterData;
 - (void)removeDevice:(MTRDevice *)device;
 
+/**
+ * Called by MTRDevice object when their dealloc is called, so the controller can notify interested delegate that active devices have changed
+ */
+- (void)deviceDeallocated;
+
 @end
 
 /**

--- a/src/darwin/Framework/CHIPTests/MTRPerControllerStorageTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRPerControllerStorageTests.m
@@ -1787,9 +1787,9 @@ static void OnBrowse(DNSServiceRef serviceRef, DNSServiceFlags flags, uint32_t i
     XCTAssertNotNil([dataStore findResumptionInfoByNodeID:deviceID]);
     XCTAssertNotNil([dataStore getStoredDeviceDataForNodeID:deviceID]);
     XCTAssertNotNil([dataStore getStoredClusterDataForNodeID:deviceID]);
-    __auto_type * nodesWithStoredData = [controller nodesWithStoredData];
+    __auto_type * nodesWithStoredData = controller.nodesWithStoredData;
     XCTAssertTrue([nodesWithStoredData containsObject:deviceID]);
-    XCTAssertEqualObjects(nodesWithStoredData, [dataStore nodesWithStoredData]);
+    XCTAssertEqualObjects(nodesWithStoredData, dataStore.nodesWithStoredData);
     XCTAssertEqualObjects(nodesWithStoredData, deviceAttributeCounts.allKeys);
 
     [controller forgetDeviceWithNodeID:deviceID];
@@ -1798,9 +1798,9 @@ static void OnBrowse(DNSServiceRef serviceRef, DNSServiceFlags flags, uint32_t i
     XCTAssertNil([dataStore findResumptionInfoByNodeID:deviceID]);
     XCTAssertNil([dataStore getStoredDeviceDataForNodeID:deviceID]);
     XCTAssertNil([dataStore getStoredClusterDataForNodeID:deviceID]);
-    nodesWithStoredData = [controller nodesWithStoredData];
+    nodesWithStoredData = controller.nodesWithStoredData;
     XCTAssertFalse([nodesWithStoredData containsObject:deviceID]);
-    XCTAssertEqualObjects(nodesWithStoredData, [dataStore nodesWithStoredData]);
+    XCTAssertEqualObjects(nodesWithStoredData, dataStore.nodesWithStoredData);
 
     [controller shutdown];
     XCTAssertFalse([controller isRunning]);

--- a/src/darwin/Framework/CHIPTests/MTRPerControllerStorageTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRPerControllerStorageTests.m
@@ -103,6 +103,19 @@ static const uint16_t kSubscriptionPoolBaseTimeoutInSeconds = 30;
 }
 @end
 
+@interface MTRPerControllerStorageTestsDeallocDelegate : NSObject <MTRDeviceControllerDelegate>
+@property (nonatomic, nullable) dispatch_block_t onDevicesChanged;
+@end
+
+@implementation MTRPerControllerStorageTestsDeallocDelegate
+- (void)devicesChangedForController:(MTRDeviceController *)controller
+{
+    if (self.onDevicesChanged) {
+        self.onDevicesChanged();
+    }
+}
+@end
+
 @interface MTRPerControllerStorageTestsCertificateIssuer : NSObject <MTROperationalCertificateIssuer>
 - (instancetype)initWithRootCertificate:(MTRCertificateDERBytes)rootCertificate
                 intermediateCertificate:(MTRCertificateDERBytes _Nullable)intermediateCertificate
@@ -3652,9 +3665,31 @@ static void OnBrowse(DNSServiceRef serviceRef, DNSServiceFlags flags, uint32_t i
     // We should have established CASE using our operational key.
     XCTAssertEqual(operationalKeys.signatureCount, 1);
 
+    // Before the test, clear the device controller in-memory MapTable
+    [controller forgetDeviceWithNodeID:deviceID];
+
     __block BOOL subscriptionReportEnd1 = NO;
     XCTestExpectation * subscriptionCallbackDeleted = [self expectationWithDescription:@"Subscription callback deleted"];
+    XCTestExpectation * controllerAddedDevice = [self expectationWithDescription:@"Controller added device"];
+    XCTestExpectation * controllerRemovedDevice = [self expectationWithDescription:@"Controller removed device"];
     @autoreleasepool {
+        // Expected the test device was added and removed
+        MTRPerControllerStorageTestsDeallocDelegate * controllerDelegate = [[MTRPerControllerStorageTestsDeallocDelegate alloc] init];
+        __block NSUInteger lastDeviceCount = controller.devices.count;
+        controllerDelegate.onDevicesChanged = ^{
+            // Use self as lock for lastDeviceCount access, so sanitizer doesn't complain
+            @synchronized(self) {
+                NSArray<MTRDevice *> * devices = controller.devices;
+                if (devices.count > lastDeviceCount) {
+                    [controllerAddedDevice fulfill];
+                } else if (devices.count < lastDeviceCount) {
+                    [controllerRemovedDevice fulfill];
+                }
+                lastDeviceCount = devices.count;
+            }
+        };
+        [controller addDeviceControllerDelegate:controllerDelegate queue:queue];
+
         __auto_type * device = [MTRDevice deviceWithNodeID:deviceID controller:controller];
         __auto_type * delegate = [[MTRDeviceTestDelegate alloc] init];
 
@@ -3675,13 +3710,16 @@ static void OnBrowse(DNSServiceRef serviceRef, DNSServiceFlags flags, uint32_t i
         [device setDelegate:delegate queue:queue];
 
         [self waitForExpectations:@[ subscriptionReportBegin ] timeout:60];
+
+        XCTAssertEqual(controller.devices.count, 1);
     }
 
     // report should still be ongoing
     XCTAssertFalse(subscriptionReportEnd1);
+    XCTAssertEqual(controller.devices.count, 0);
 
     // dealloc -> delete should be called soon after the autoreleasepool reaps
-    [self waitForExpectations:@[ subscriptionCallbackDeleted ] timeout:60];
+    [self waitForExpectations:@[ subscriptionCallbackDeleted, controllerAddedDevice, controllerRemovedDevice ] timeout:60];
 
     // Reset our commissionee.
     __auto_type * baseDevice = [MTRBaseDevice deviceWithNodeID:deviceID controller:controller];

--- a/src/darwin/Framework/CHIPTests/TestHelpers/MTRTestDeclarations.h
+++ b/src/darwin/Framework/CHIPTests/TestHelpers/MTRTestDeclarations.h
@@ -44,7 +44,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable NSArray<NSNumber *> *)_fetchClusterIndexForNodeID:(NSNumber *)nodeID endpointID:(NSNumber *)endpointID;
 - (nullable MTRDeviceClusterData *)_fetchClusterDataForNodeID:(NSNumber *)nodeID endpointID:(NSNumber *)endpointID clusterID:(NSNumber *)clusterID;
 - (nullable NSDictionary<NSString *, id> *)getStoredDeviceDataForNodeID:(NSNumber *)nodeID;
-- (NSArray<NSNumber *> *)nodesWithStoredData;
+@property (readonly, nonatomic) NSArray<NSNumber *> * nodesWithStoredData;
 @end
 
 // Declare internal methods for testing

--- a/src/platform/silabs/wifi/SiWx/ncp/efx32_ncp_host.c
+++ b/src/platform/silabs/wifi/SiWx/ncp/efx32_ncp_host.c
@@ -15,6 +15,12 @@
  *
  ******************************************************************************/
 
+#include <platform/silabs/wifi/SiWx/ncp/sl_board_configuration.h>
+#include <platform/silabs/wifi/ncp/spi_multiplex.h>
+
+#include <stdbool.h>
+#include <string.h>
+
 #include "cmsis_os2.h"
 #include "dmadrv.h"
 #include "em_cmu.h"
@@ -25,17 +31,14 @@
 #include "sl_constants.h"
 #include "sl_rsi_utility.h"
 #include "sl_si91x_host_interface.h"
-#include "sl_si91x_ncp_utility.h"
 #include "sl_si91x_status.h"
 #include "sl_spidrv_exp_config.h"
 #include "sl_spidrv_instances.h"
 #include "sl_status.h"
 #include "sl_wifi_constants.h"
 #include "spidrv.h"
-#include <platform/silabs/wifi/SiWx/ncp/sl_board_configuration.h>
-#include <platform/silabs/wifi/ncp/spi_multiplex.h>
-#include <stdbool.h>
-#include <string.h>
+
+#include "sl_si91x_ncp_utility.h"
 
 #if defined(SL_CATLOG_POWER_MANAGER_PRESENT)
 #include "sl_power_manager.h"
@@ -45,28 +48,28 @@
 #include "sl_board_control.h"
 #endif // SL_BOARD_NAME
 
-#define LDMA_MAX_TRANSFER_LENGTH 4096
-#define LDMA_DESCRIPTOR_ARRAY_LENGTH (LDMA_MAX_TRANSFER_LENGTH / 2048)
-#define SPI_HANDLE sl_spidrv_exp_handle
 #define MAX_DATA_PACKET_SIZE 1800
+
+static const uint8_t ncp_transfer_timeout_ms = 1000;
 
 // use SPI handle for EXP header (configured in project settings)
 extern SPIDRV_Handle_t sl_spidrv_exp_handle;
-static uint8_t dummy_buffer[MAX_DATA_PACKET_SIZE]   = { 0 };
-static sl_si91x_host_init_configuration init_config = { 0 };
-
-uint32_t rx_ldma_channel;
-uint32_t tx_ldma_channel;
-osMutexId_t ncp_transfer_mutex = 0;
+#define SPI_HANDLE sl_spidrv_exp_handle
 
 static osSemaphoreId_t transfer_done_semaphore = NULL;
+static osMutexId_t ncp_transfer_mutex          = NULL;
 
-static void gpio_interrupt([[maybe_unused]] uint8_t interrupt_number)
+static sl_si91x_host_init_configuration init_config = { 0 };
+static uint8_t dummy_buffer[MAX_DATA_PACKET_SIZE]   = { 0 };
+
+static void gpio_interrupt(uint8_t interrupt_number)
 {
+    UNUSED_PARAMETER(interrupt_number);
     if (NULL != init_config.rx_irq)
     {
         init_config.rx_irq();
     }
+    return;
 }
 
 static void spi_dma_callback(struct SPIDRV_HandleData * handle, Ecode_t transferStatus, int itemsTransferred)
@@ -95,47 +98,11 @@ static void efx32_spi_init(void)
     NVIC_SetPriority(GPIO_ODD_IRQn, PACKET_PENDING_INT_PRI);
     GPIOINT_CallbackRegister(INTERRUPT_PIN.pin, gpio_interrupt);
     GPIO_PinModeSet(INTERRUPT_PIN.port, INTERRUPT_PIN.pin, gpioModeInputPullFilter, 0);
+
+    // Configure the GPIO external interrupt for active high configuration
     GPIO_ExtIntConfig(INTERRUPT_PIN.port, INTERRUPT_PIN.pin, INTERRUPT_PIN.pin, true, false, true);
-}
 
-Ecode_t si91x_SPIDRV_MTransfer(SPIDRV_Handle_t handle, const void * txBuffer, void * rxBuffer, int count,
-                               SPIDRV_Callback_t callback)
-{
-    USART_TypeDef * usart = handle->initData.port;
-    uint8_t * tx          = (txBuffer != NULL) ? (uint8_t *) txBuffer : dummy_buffer;
-    uint8_t * rx          = (rxBuffer != NULL) ? (uint8_t *) rxBuffer : dummy_buffer;
-
-    // For transfers less than 16 bytes, directly interacting with USART buffers is faster than using DMA
-    if (count < 16)
-    {
-        while (count > 0)
-        {
-            while (!(usart->STATUS & USART_STATUS_TXBL))
-            {
-            }
-            usart->TXDATA = (uint32_t) *tx;
-            while (!(usart->STATUS & USART_STATUS_TXC))
-            {
-            }
-            *rx = (uint8_t) usart->RXDATA;
-            if (txBuffer != NULL)
-            {
-                tx++;
-            }
-            if (rxBuffer != NULL)
-            {
-                rx++;
-            }
-            count--;
-        }
-        // callback(handle, ECODE_EMDRV_SPIDRV_OK, 0);
-        return ECODE_EMDRV_SPIDRV_OK;
-    }
-    else
-    {
-        SPIDRV_MTransfer(handle, tx, rx, count, callback);
-    }
-    return ECODE_EMDRV_SPIDRV_BUSY;
+    return;
 }
 
 void sl_si91x_host_set_sleep_indicator(void)
@@ -156,13 +123,9 @@ uint32_t sl_si91x_host_get_wake_indicator(void)
 sl_status_t sl_si91x_host_init(const sl_si91x_host_init_configuration * config)
 {
 #if SL_SPICTRL_MUX
-    sl_status_t status = sl_board_disable_display();
-    if (SL_STATUS_OK != status)
-    {
-        SILABS_LOG("sl_board_disable_display failed with error: %x", status);
-        return status;
-    }
+    spi_board_init();
 #endif // SL_SPICTRL_MUX
+
     init_config.rx_irq      = config->rx_irq;
     init_config.rx_done     = config->rx_done;
     init_config.boot_option = config->boot_option;
@@ -170,16 +133,13 @@ sl_status_t sl_si91x_host_init(const sl_si91x_host_init_configuration * config)
     // Enable clock (not needed on xG21)
     CMU_ClockEnable(cmuClock_GPIO, true);
 
-#if SL_SPICTRL_MUX
-    spi_board_init();
-#endif // SL_SPICTRL_MUX
-
     if (transfer_done_semaphore == NULL)
     {
-        transfer_done_semaphore = osSemaphoreNew(1, 0, NULL);
+        // initialize and acquire the semaphore
+        transfer_done_semaphore = osSemaphoreNew(1, 1, NULL);
     }
 
-    if (ncp_transfer_mutex == 0)
+    if (ncp_transfer_mutex == NULL)
     {
         ncp_transfer_mutex = osMutexNew(NULL);
     }
@@ -187,7 +147,7 @@ sl_status_t sl_si91x_host_init(const sl_si91x_host_init_configuration * config)
     efx32_spi_init();
 
     // Start reset line low
-    GPIO_PinModeSet(RESET_PIN.port, RESET_PIN.pin, gpioModePushPull, 0);
+    GPIO_PinModeSet(RESET_PIN.port, RESET_PIN.pin, gpioModeWiredAnd, 0);
 
     // Configure interrupt, sleep and wake confirmation pins
     GPIO_PinModeSet(SLEEP_CONFIRM_PIN.port, SLEEP_CONFIRM_PIN.pin, gpioModeWiredOrPullDown, 1);
@@ -215,26 +175,56 @@ void sl_si91x_host_enable_high_speed_bus() {}
  * @section description
  * This API is used to transfer/receive data to the Wi-Fi module through the SPI interface.
  */
+
+sl_status_t sl_si91x_host_spi_cs_assert()
+{
+#if SL_SPICTRL_MUX
+    sl_wfx_host_spi_cs_assert();
+#endif // SL_SPICTRL_MUX
+    return SL_STATUS_OK;
+}
+
+sl_status_t sl_si91x_host_spi_cs_deassert()
+{
+#if SL_SPICTRL_MUX
+    sl_wfx_host_spi_cs_deassert();
+#endif // SL_SPICTRL_MUX
+    return SL_STATUS_OK;
+}
+
 sl_status_t sl_si91x_host_spi_transfer(const void * tx_buffer, void * rx_buffer, uint16_t buffer_length)
 {
     osMutexAcquire(ncp_transfer_mutex, 0xFFFFFFFFUL);
 
-#if SL_SPICTRL_MUX
-    sl_wfx_host_spi_cs_assert();
-#endif // SL_SPICTRL_MUX
+    uint8_t * tx_buf = (tx_buffer != NULL) ? (uint8_t *) tx_buffer : dummy_buffer;
+    uint8_t * rx_buf = (rx_buffer != NULL) ? (uint8_t *) rx_buffer : dummy_buffer;
+    Ecode_t status   = ECODE_EMDRV_SPIDRV_OK;
 
-    if (ECODE_EMDRV_SPIDRV_BUSY == si91x_SPIDRV_MTransfer(SPI_HANDLE, tx_buffer, rx_buffer, buffer_length, spi_dma_callback))
+    // If the buffer length is greater than the high speed transfer threshold, use DMA transfer
+    status = SPIDRV_MTransfer(SPI_HANDLE, tx_buf, rx_buf, buffer_length, spi_dma_callback);
+
+    if (ECODE_EMDRV_SPIDRV_OK != status)
     {
-        if (osSemaphoreAcquire(transfer_done_semaphore, 1000) != osOK)
-        {
-            BREAKPOINT();
-        }
+        SILABS_LOG("ERR: SPI failed with error:%x (tx%x rx%x)", status, (uint32_t) tx_buf, (uint32_t) rx_buf);
+        osMutexRelease(ncp_transfer_mutex);
+
+        return SL_STATUS_FAIL;
+    }
+
+    if (osSemaphoreAcquire(transfer_done_semaphore, ncp_transfer_timeout_ms) != osOK)
+    {
+        int itemsTransferred = 0;
+        int itemsRemaining   = 0;
+        SPIDRV_GetTransferStatus(SPI_HANDLE, &itemsTransferred, &itemsRemaining);
+        SILABS_LOG("ERR: SPI timed out %d/%d (rx%x rx%x)", itemsTransferred, itemsRemaining, (uint32_t) tx_buf, (uint32_t) rx_buf);
+        SPIDRV_AbortTransfer(SPI_HANDLE);
+        osMutexRelease(ncp_transfer_mutex);
+
+        return SL_STATUS_SPI_BUSY;
     }
 
     osMutexRelease(ncp_transfer_mutex);
-#if SL_SPICTRL_MUX
-    sl_wfx_host_spi_cs_deassert();
-#endif // SL_SPICTRL_MUX
+
     return SL_STATUS_OK;
 }
 
@@ -245,7 +235,7 @@ void sl_si91x_host_hold_in_reset(void)
 
 void sl_si91x_host_release_from_reset(void)
 {
-    GPIO_PinModeSet(RESET_PIN.port, RESET_PIN.pin, gpioModeWiredOrPullDown, 1);
+    GPIO_PinOutSet(RESET_PIN.port, RESET_PIN.pin);
 }
 
 void sl_si91x_host_enable_bus_interrupt(void)

--- a/third_party/silabs/silabs_board.gni
+++ b/third_party/silabs/silabs_board.gni
@@ -66,13 +66,6 @@ declare_args() {
   chip_enable_ble_rs911x = use_rs9116 || use_SiWx917
 }
 
-# TODO - This needs to be removed once multiplexing issues resolved
-if (use_SiWx917) {
-  disable_lcd = true
-  show_qr_code = false
-  use_external_flash = false
-}
-
 if (silabs_board == "") {
   silabs_board = getenv("SILABS_BOARD")
 }

--- a/third_party/silabs/silabs_board.gni
+++ b/third_party/silabs/silabs_board.gni
@@ -198,7 +198,7 @@ declare_args() {
 
   # UART log forwarding
   # Default true for the wifi soc and false for EFR32 boards
-  sl_uart_log_output = wifi_soc
+  sl_uart_log_output = true
 }
 
 # Silabs mcu family and mcu model must be specified


### PR DESCRIPTION
### Changelog
- Refactors the host SPI transfer API for use of a single async SPI DMA call.
- Clean-up of the interface file to remove unnecessary code
- Requires fixes from the SDK to enable the LCD support on the NCP/RCP combination.
- 
### Testing
Manually tested for init and sanity testing.

